### PR TITLE
Bug fix login Google Chrome

### DIFF
--- a/html/cgi-bin/login.sh
+++ b/html/cgi-bin/login.sh
@@ -46,11 +46,11 @@ EOF
 
   #enviar cookie
   ((ESPIRA= AGORA + 36000))
-  printf "Set-Cookie: login=$LOGIN; Path=/;  expires=$(date --date=@$ESPIRA)\n"
-  printf "Set-Cookie: hash=$NOVAHASH; Path=/; expires=$(date --date=@$ESPIRA)\n"
   printf "Content-type: text/html\n\n"
   cat << EOF
   <script type="text/javascript">
+    document.cookie="login=$LOGIN; expires=$(date --utc --date=@$ESPIRA); Path=/"
+    document.cookie="hash=$NOVAHASH; expires=$(date --utc --date=@$ESPIRA); Path=/"
     top.location.href = "$BASEURL/cgi-bin/contest.sh/$CONTEST"
   </script>
 


### PR DESCRIPTION
Correction of the login bug in Google Chrome. Google Chrome did not create cookies that were passed through the "Set-Cookie" attribute. The solution was to create the cookies through JavaScript.