### PR TITLE
Adicionada nova forma de inserir contests.

### DIFF
--- a/html/cgi-bin/admin.sh
+++ b/html/cgi-bin/admin.sh
@@ -15,6 +15,7 @@
 #along with CD-MOJ.  If not, see <http://www.gnu.org/licenses/>.
 
 source common.sh
+source new-contest.sh
 
 #o contest é valido, tem que verificar o login
 if verifica-login admin| grep -q Nao; then
@@ -22,90 +23,30 @@ if verifica-login admin| grep -q Nao; then
 fi
 
 #ok logados
-AGORA="$(date +%s)"
 LOGIN=$(pega-login)
 NOME="$(pega-nome admin)"
-TMP=$(mktemp)
-POST=$TMP
-cat > $TMP
-if [[ "x$(< $TMP)" != "x" ]]; then
-  FILENAME="$(grep -a 'filename'  "$POST" |sed -e 's/.*filename="\(.*\)".*/\1/g')"
-  fd='Content-Type: '
-  boundary="$(head -n1 "$POST")"
-  INICIO=$(cat -n $TMP| grep -a Content-Type|awk '{print $1}')
-  ((INICIO++))
-  sed -i  -e "1,${INICIO}d" $TMP
-  chmod a+r "$TMP"
-  cp $TMP $SUBMISSIONDIR/admin:$AGORA:$RANDOM:$LOGIN:newcontest
-fi
-rm $TMP
-sleep 3
 
 cabecalho-html
 printf "<h1>Administrador $NOME</h1>\n"
-
 printf "<h2>Trocar Senha</h2>\n"
 printf "<p> - <a href='$BASEURL/cgi-bin/passwd.sh/admin'>passwd</a></p><br/>"
 
-printf "<h2>Baixe o contest template</h2>\n"
-printf "<p> <a href=\"$BASEURL/contests/sample.tar.bz2\">AQUI</a></h1>\n"
-printf "<h3>Formato do arquivo contest-description.txt</h3>"
 cat << EOF
-<table border=1>
-<tr><td>CONTEST_ID</td><td>ID do contest em um nome padrao UNIX, sem espaco</td></tr>
-<tr><td>"Nome Completo do Contest"</td><td>Nome completo do contest para
-aparecer na tela inicial, deve ser escrito com ASPAS</td></tr>
-<tr><td>INICIO-da-prova</td><td>Inicio da prova em segundos, no padrão UNIX gere com
-o comando date, por exemplo, se a prova deve começar às 15:00 de hoje:
-<br/>
-<pre>
-date --date="15:00:00 today" +%s
-</pre></td></tr>
-<tr><td>TERMINO-da-prova</td><td>Termino da prova em segundos, gere com o
-comando date, por exemplo, se a prova deve terminar hoje às 17:00:<br/>
-<pre> date --date="17:00:00 today" +%s</pre></tr></td>
-<tr><td>N</td><td>Numero inteiro com a quantidade de problemas
-da prova, depois serão N linhas com as descrições dos problemas</td></tr>
-<tr><td>SITE ID "Nome Completo" Nome_Pequeno link-enunciado</td><td>
-N linhas com esse formato, onde cada elemento representa:
-<ul>
-  <li>SITE: pode ser spoj-br spoj-www</li>
-  <li>ID: é o ID do problema no SITE</li>
-  <li>"Nome completo": nome full do problema, entre ASPAS</li>
-  <li>Nome_pequeno: pode ser Letra ou numero mas coloque em ordem nesse
-  arquivo</li>
-  <li>link-enunciado: pode ser:
-    <ul>
-      <li> site , redireciona pro SITE</li>
-      <li>um link inicando por http://</li>
-      <li>none para nao ter um enunciado</li>
-      <li>o nome de um arquivo dentro do diretorio enunciados/</li>
-    </ul>
-  </li>
-</ul></td></tr>
-<tr><td>M</td><td>Número Inteiro representando a quantidade de usuários
-cadastrados</td></tr>
-<tr><td>login:senha:Nome Completo</td><td>M linhas com os usuarios que tem
-permissão de logar nesse contest. Todo login que terminar com .admin será
-considerado um usuário do tipo Administrador e terá acesso a várias
-funcionalidades administrativas, como acesso contínuo às Estatísticas mesmo
-sem ter PARTIALSTATISTIC=1.</td></tr>
-</table>
+  <script type="text/javascript" src="/js/simpletabs_1.3.packed.js"></script>
+  <style type="text/css" media="screen">
+    @import "/css/simpletabs.css";
+  </style>
 EOF
 
-echo "<br/><br/>"
-printf "<h2>Envie o novo contest</h2>"
-
 cat << EOF
-<p> Reenviar um contest já existente irá recriá-lo sem perder as submissões
-</p>
-<form enctype="multipart/form-data" action="$BASEURL/cgi-bin/admin.sh" method="post">
-  <input type="hidden" name="MAX_FILE_SIZE" value="30000">
-  File: <input name="myfile" type="file">
-  <br/>
-  <input type="submit" value="Submit">
-  <br/>
-</form>
+<div class="simpleTabs">
+            <ul class="simpleTabsNavigation">
+                <li><a href="#">Old School</a></li>
+                <li><a href="#">Form</a></li>
+            </ul>
+            <div class="simpleTabsContent">$(new-contest-old)</div>
+            <div class="simpleTabsContent">$(new-contest-form)</div>
+        </div>
 EOF
 echo "<br/><br/>"
 printf "<h2>Últimas mensagens do LOG do admin $LOGIN</h2>"
@@ -113,5 +54,4 @@ echo "<pre>"
 cat $CONTESTSDIR/admin/$LOGIN.msgs
 echo "</pre>"
 cat ../footer.html
-
 exit 0

--- a/html/cgi-bin/formulario.sh
+++ b/html/cgi-bin/formulario.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#This file is part of CD-MOJ.
+#
+#CD-MOJ is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#CD-MOJ is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with CD-MOJ.  If not, see <http://www.gnu.org/licenses/>.
+
+source common.sh
+#o contest é valido, tem que verificar o login
+#if verifica-login admin| grep -q Nao; then
+#  tela-login admin
+#fi
+
+#ok logados
+AGORA="$(date +%s)"
+LOGIN=$(pega-login)
+NOME="$(pega-nome admin)"
+TMP=$(mktemp)
+TMP_DIR=$(mktemp -d)
+mkdir $TMP_DIR/enunciados
+DIR_ENUNCIADOS="$TMP_DIR/enunciados"
+POST=$TMP
+cat > $TMP
+if [[ "x$(< $TMP)" != "x" ]]; then
+  BOUNDARY="$(head -n1 "$POST")"
+  CONTEST_ID="$(grep -a -A3 'contest_id' "$POST"|tr '\n' '&'|cut '-d&' -f3|sed -e 's/\r//')"
+  NOME_COMPLETO="$(grep -a -A3 'nome_completo' "$POST"|tr '\n' '&'|cut '-d&' -f3|sed -e 's/\r//')"
+  DATA_INICIO="$(grep -a -A3 'data_inicio' "$POST"|tr '\n' '&'|cut '-d&' -f3|sed -e 's/\r//')"
+  HORA_INICIO="$(grep -a -A3 'hora_inicio' "$POST"|tr '\n' '&'|cut '-d&' -f3|sed -e 's/\r//')"
+  INICIO=$(date --date="$HORA_INICIO $DATA_INICIO" +%s)
+  DATA_FIM="$(grep -a -A3 'data_fim' "$POST"|tr '\n' '&'|cut '-d&' -f3|sed -e 's/\r//')"
+  HORA_FIM="$(grep -a -A3 'hora_fim' "$POST"|tr '\n' '&'|cut '-d&' -f3|sed -e 's/\r//')"
+  TERMINO=$(date --date="$HORA_FIM $DATA_FIM" +%s)
+  USERS="$(sed -n "/users/,/${BOUNDARY}/p" "$POST"|sed '1,2d;$d'|tr -d '\r')"
+  N_USERS="$(sed -n "/users/,/${BOUNDARY}/p" "$POST"|sed '1,2d;$d'|wc -l)"
+  SITE_ID="$(grep -a -E 'cdmoj|spoj\-br|spoj\-www' "$POST"|tr '\n' '&'|tr -d '\r')"
+  ID_SITE="$(grep -a -A2 'id_site' "$POST"|sed -e 's/\--/@/g'|tr '\n' '&'|tr -d '\r')"
+  TITULO="$(grep -a -A2 'titulo' "$POST"|sed -e 's/\--/@/g'|tr '\n' '&'|tr -d '\r')"
+  NOME_PEQUENO="$(grep -a -A2 'nome_pequeno' "$POST"|sed -e 's/\--/@/g'|tr '\n' '&'|tr -d '\r')"
+  ENUNCIADOS="$(grep -a 'filename' "$POST"|tr '\n' '&'|tr -d '\r')"
+  N_CONTESTS="$(grep -a 'site_id' "$POST"|wc -l)"
+  prob=""
+  LINHA=""
+  cont=1
+  while (("$cont" <= "$N_CONTESTS")); do
+    prob+="$(echo $SITE_ID|cut '-d&' -f"$cont") "
+    prob+="$(echo $ID_SITE|sed -e 's/@&/@/g'|cut '-d@' -f"$cont"|cut '-d&' -f3) "
+    prob+="\"$(echo $TITULO|sed -e 's/@&/@/g'|cut '-d@' -f"$cont"|cut '-d&' -f3)\" "
+    prob+="$(echo $NOME_PEQUENO|sed -e 's/@&/@/g'|cut '-d@' -f"$cont"|cut '-d&' -f3) "
+    prob+="$(echo $ENUNCIADOS|cut '-d&' -f"$cont"|cut '-d=' -f3|sed -e 's/\"//g')"
+    LINHA+=$prob'\n'
+    prob=""
+    ((cont++))
+  done
+  CONTEST="$(echo -e $LINHA)"
+  N_ENUNCIADOS="$(grep -a 'enunciado_problema' "$POST"|wc -l)"
+  cont=1;
+  while (( "$cont" <= "$N_ENUNCIADOS" )); do
+    FILE_NAME="$(echo $ENUNCIADOS|tr '\n' '&'|cut '-d&' -f$cont|cut '-d=' -f3|sed -e 's/\"//g')"
+    sed -n "/${FILE_NAME}/,/${BOUNDARY}/p" "$POST"|sed '1,3d;$d' > "$TMP_DIR/enunciados/$FILE_NAME"
+    ((cont++))
+  done
+  cat << EOF > $TMP_DIR/contest-description.txt
+$CONTEST_ID
+"$NOME_COMPLETO"
+$INICIO
+$TERMINO
+$N_CONTESTS
+$CONTEST
+$N_USERS
+$USERS
+EOF
+tar cf $SUBMISSIONDIR/admin:$AGORA:$RANDOM:$LOGIN:newcontest $TMP_DIR/enunciados $TMP_DIR/contest-description.txt
+fi
+cabecalho-html
+#echo "<pre>"
+#cat $TMP
+#echo "</pre>"
+rm -rf $TMP $TMP_DIR
+#sleep 3
+echo "<br/><br/>"
+printf "<h2>Últimas mensagens do LOG do admin $LOGIN</h2>"
+echo "<pre>"
+cat $CONTESTSDIR/admin/$LOGIN.msgs
+echo "</pre>"
+cat ../footer.html
+
+exit 0

--- a/html/cgi-bin/new-contest.sh
+++ b/html/cgi-bin/new-contest.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#This file is part of CD-MOJ.
+#
+#CD-MOJ is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#CD-MOJ is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with CD-MOJ.  If not, see <http://www.gnu.org/licenses/>.
+
+source common.sh
+
+function new-contest-old() {
+  #ok logados
+  AGORA="$(date +%s)"
+  LOGIN=$(pega-login)
+  NOME="$(pega-nome admin)"
+  TMP=$(mktemp)
+  POST=$TMP
+  cat > $TMP
+  if [[ "x$(< $TMP)" != "x" ]]; then
+    FILENAME="$(grep -a 'filename'  "$POST" |sed -e 's/.*filename="\(.*\)".*/\1/g')"
+    fd='Content-Type: '
+    boundary="$(head -n1 "$POST")"
+    INICIO=$(cat -n $TMP| grep -a Content-Type|awk '{print $1}')
+    ((INICIO++))
+    sed -i  -e "1,${INICIO}d" $TMP
+    chmod a+r "$TMP"
+    cp $TMP $SUBMISSIONDIR/admin:$AGORA:$RANDOM:$LOGIN:newcontest
+  fi
+  rm $TMP
+  #sleep 3
+  printf "<h2>Baixe o contest template</h2>\n"
+  printf "<p> <a href=\"$BASEURL/contests/sample.tar.bz2\">AQUI</a></h1>\n"
+  printf "<h3>Formato do arquivo contest-description.txt</h3>"
+cat << EOF
+<table border=1>
+<tr><td>CONTEST_ID</td><td>ID do contest em um nome padrao UNIX, sem espaco</td></tr>
+<tr><td>"Nome Completo do Contest"</td><td>Nome completo do contest para
+aparecer na tela inicial, deve ser escrito com ASPAS</td></tr>
+<tr><td>INICIO-da-prova</td><td>Inicio da prova em segundos, no padrão UNIX gere com
+o comando date, por exemplo, se a prova deve começar às 15:00 de hoje:
+<br/>
+<pre>
+date --date="15:00:00 today" +%s
+</pre></td></tr>
+<tr><td>TERMINO-da-prova</td><td>Termino da prova em segundos, gere com o
+comando date, por exemplo, se a prova deve terminar hoje às 17:00:<br/>
+<pre> date --date="17:00:00 today" +%s</pre></tr></td>
+<tr><td>N</td><td>Numero inteiro com a quantidade de problemas
+da prova, depois serão N linhas com as descrições dos problemas</td></tr>
+<tr><td>SITE ID "Nome Completo" Nome_Pequeno link-enunciado</td><td>
+N linhas com esse formato, onde cada elemento representa:
+<ul>
+  <li>SITE: pode ser spoj-br spoj-www</li>
+  <li>ID: é o ID do problema no SITE</li>
+  <li>"Nome completo": nome full do problema, entre ASPAS</li>
+  <li>Nome_pequeno: pode ser Letra ou numero mas coloque em ordem nesse
+  arquivo</li>
+  <li>link-enunciado: pode ser:
+    <ul>
+      <li> site , redireciona pro SITE</li>
+      <li>um link inicando por http://</li>
+      <li>none para nao ter um enunciado</li>
+      <li>o nome de um arquivo dentro do diretorio enunciados/</li>
+    </ul>
+  </li>
+</ul></td></tr>
+<tr><td>M</td><td>Número Inteiro representando a quantidade de usuários
+cadastrados</td></tr>
+<tr><td>login:senha:Nome Completo</td><td>M linhas com os usuarios que tem
+permissão de logar nesse contest. Todo login que terminar com .admin será
+considerado um usuário do tipo Administrador e terá acesso a várias
+funcionalidades administrativas, como acesso contínuo às Estatísticas mesmo
+sem ter PARTIALSTATISTIC=1.</td></tr>
+</table>
+EOF
+
+  echo "<br/><br/>"
+  printf "<h2>Envie o novo contest</h2>"
+
+cat << EOF
+  <p> Reenviar um contest já existente irá recriá-lo sem perder as submissões </p>
+  <form enctype="multipart/form-data" action="$BASEURL/cgi-bin/admin.sh" method="post">
+    <input type="hidden" name="MAX_FILE_SIZE" value="30000">
+    File: <input name="myfile" type="file">
+    <br/>
+    <input type="submit" value="Submit">
+    <br/>
+  </form>
+EOF
+}
+
+function new-contest-form() {
+  sed -e "s/\$LOGIN/${LOGIN}_$(date +%s)/" ../new-contest-form.html
+}

--- a/html/new-contest-form.html
+++ b/html/new-contest-form.html
@@ -1,0 +1,101 @@
+<html>
+  <head>
+    <script language="javascript">
+      var cont = 65;
+      function newContest() {
+        let novo = document.querySelector('div.contest').cloneNode(true);
+        btn = document.getElementById('botoes');
+        novoInputs = novo.getElementsByTagName('input');
+        for (let i = 0; i < novoInputs.length; i++) {
+          novoInputs[i].value = "";
+          if (i==(novoInputs.length - 2)) {
+            cont+=1;
+            novoInputs[i].value = String.fromCharCode(cont);
+          }
+        }
+        btn.parentNode.insertBefore(novo, btn.previousSibling);
+      }
+    </script>
+   </head>
+   <style>
+     #SITE_ID,#ID_SITE,#NOME_COMPLETO_SITE,#ENUNCIADO{
+         width: 99%;
+     }
+     #NOME_PEQUENO{
+       width: 25%
+     }
+   </style>
+  <body>
+      <fieldset>
+        <legend>NOVO CONTEST</legend>
+        <form method="post" action="http://localhost/cgi-bin/formulario.sh" id="FormIdContest" enctype="multipart/form-data">
+          <table>
+            <tr>
+              <td align="left">
+                <label id="Contest_Id_label">Contest ID</label>
+                <input type="text" name="contest_id" id="Contest_Id_input" size="20" value="$LOGIN">
+              </td>
+              <td align="left">
+                <label id="Nome_Completo_label">Nome Completo</label>
+                <input type="text" name="nome_completo" id="Nome_Completo_input" size="20">
+              </td>
+            </tr>
+            <tr>
+              <td align="left">
+                <label id="Data_Inicio_label">Data de Inicio</label>
+                <input type="date" name="data_inicio" id="Data_Inicio_input" size="20">
+              </td>
+              <td align="left">
+                <label id="Hora_Inicio_label">Hora de Inicio</label>
+                <input type="time" name="hora_inicio" id="Hora_Inicio_input" size="20">
+              </td>
+            </tr>
+            <tr>
+              <td align="left">
+                <label id="Data_Fim_label">Data Final</label>
+                <input type="date" name="data_fim" id="Data_Fim_input" size="20">
+              </td>
+              <td align="left">
+                <label id="Hora_Final_label">Hora Final</label>
+                <input type="time" name="hora_fim" id="Hora_Final_input" size="20">
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <label align="left">Usuarios</label>
+                <textarea align="left" name="users" id="Users_TextArea"></textarea>
+              </td>
+            </tr>
+            </table>
+            <div class="contest">
+              <table>
+                <tr>
+                  <td>
+                  <label>Site ID:</label>
+                    <select name="site_id" id="SITE_ID">
+                      <option value="cdmoj">CD-MOJ</option>
+                      <option value="spoj-br">SPOJ-BR</option>
+                      <option value="spoj-www">SPOJ-WWW</option>
+                    </select></td>
+                    <td><label>ID Contest:</label>
+                    <input type="text" name="id_site" id="ID_SITE" size="20"></td>
+                    <td><label>Título:</label>
+                    <input type="text" name="titulo" id="NOME_COMPLETO_SITE" size="20"></td>
+                    <td><label>Nome Pequeno:</label>
+                    <input type="text" name="nome_pequeno" id="NOME_PEQUENO" value="A" size="20"></td>
+                    <td><label>Enunciado:</label>
+                    <input type="file" name="enunciado_problema" id="ENUNCIADO" size="20" value="upload"></input></td>
+                    </tr>
+              </table>
+            </div>
+            <div id="botoes">
+            <table>
+              <td><button type="button" id="botao" onclick="newContest()">+</button></td>
+              <td><button type="submit" id="submitContest">Submit</button></td>
+            </table>
+          </div>
+        </form>
+        <p>Reenviar um contest já existente irá recriá-lo sem perder as submissões</p>
+      </fieldset>
+  </body>
+</html>


### PR DESCRIPTION
Adicionada a nova forma de inserir novos contests. Agora um form coleta todas
as informações necessárias, monta o arquivo contest-description, a pasta
enunciados com os arquivos de enunciados(pdf ou txt), compacta tudo em um
arquivo tar e envia para o diretório submissions. O método anterior ainda
funciona normalmente.

Signed-off-by: Gustavooguto <gustavooguto@gmail.com>